### PR TITLE
Add PlantUML support

### DIFF
--- a/client/components/containers/RootContainer.jsx
+++ b/client/components/containers/RootContainer.jsx
@@ -46,7 +46,7 @@ class RootContainer extends React.Component {
             <Route path="/saved" component={SavedView} />
             <Route path="/settings" component={SettingsView} />
             <Route path="/404" component={NotFoundView} />
-            <Route path="/:docKey" component={ReadView} />
+            <Route path="/:docKey/:renderMode?" component={ReadView} />
             <Route component={NotFoundView} />
           </Switch>
       </Router>

--- a/client/components/views/ReadView.jsx
+++ b/client/components/views/ReadView.jsx
@@ -139,7 +139,7 @@ class ReadView extends React.Component {
         secretKey: '',
         rawDisabled: false,
         editDisabled: false
-      });
+      }, () => this.loadRenderMode(this.state.renderMode));
     }
   };
 
@@ -147,6 +147,15 @@ class ReadView extends React.Component {
     this.setState({ [event.target.name]: event.target.value });
 
   loadRenderMode = (mode) => {
+    if (this.state.privacy === privacyOptions.encrypted) {
+      console.debug(
+        `Cannot load any render modes while privacy is set to ${privacyOptions.encrypted}`);
+      return;
+    }
+    if (this.state.filename) {
+      this.setState({ renderMode: 'file' });
+      return;
+    }
     this.setState({ renderMode: mode });
     switch (mode) {
       case "diff":
@@ -173,7 +182,12 @@ class ReadView extends React.Component {
   };
 
   loadPlantUml = (docKey) => {
-    doRequest({ url: `/api/${docKey}/plantuml` })
+    const params = { text: this.state.rawText };
+    doRequest({
+      method: 'POST',
+      url: `/api/${docKey}/plantuml`,
+      params
+    })
       .then((data) => {
         this.setState({ plantUml: data });
       })

--- a/client/components/views/ReadView.jsx
+++ b/client/components/views/ReadView.jsx
@@ -72,7 +72,7 @@ class ReadView extends React.Component {
   componentWillReceiveProps(nextProps, nextContext) {
     const reloadComponent = (
       (nextProps.location.state && nextProps.location.state.reload) ||
-      (this.props.match.url != nextProps.match.url)
+      (this.props.match.params.docKey != nextProps.match.params.docKey)
     );
     if (reloadComponent) {
       this.setState(this.initialState, () => {

--- a/client/components/views/ReadView.jsx
+++ b/client/components/views/ReadView.jsx
@@ -362,13 +362,15 @@ class ReadView extends React.Component {
                 <Condition condition={this.state.name}>
                   <span className="italic">&nbsp;from {this.state.name}</span>
                 </Condition>
-                <span
-                  className="ml-10 c-pointer"
-                  style={{ fontSize: 12 }}
-                  onClick={() => this.selectRenderMode('csv')}
-                >
-                  <i className="fa fa-table" />
-                </span>
+                <Condition condition={!showFile}>
+                  <span
+                    className="ml-10 c-pointer"
+                    style={{ fontSize: 12 }}
+                    onClick={() => this.selectRenderMode('csv')}
+                  >
+                    <i className="fa fa-table" />
+                  </span>
+                </Condition>
               </h3>
             </div>
 

--- a/client/styles/helpers.scss
+++ b/client/styles/helpers.scss
@@ -28,3 +28,4 @@
   user-select: none;
 }
 .w-100 { width: 100%; }
+.bg-white { background-color: white; }

--- a/client/styles/main.scss
+++ b/client/styles/main.scss
@@ -44,6 +44,7 @@ ul {
   opacity: 0.8;
   text-align: center;
   padding-top: 20px;
+  overflow: hidden;
   span {
     display: inline-block;
     font-size: 20vh;

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "mocha": "^3.2.0",
     "moment": "^2.18.1",
     "multer": "^1.3.0",
+    "node-plantuml": "^0.9.0",
     "node-sass": "^4.5.3",
     "pg": "^6.1.5",
     "prop-types": "^15.5.8",

--- a/server.js
+++ b/server.js
@@ -130,6 +130,9 @@ class Server {
     // multer for file uploads
     const upload = multer({ storage: multer.memoryStorage() }).any();
     // api calls for the server to handle
+    this.app.post('/api/:id/plantuml',
+      (req, res) =>
+        upload(req, res, (err) => this.apiController.handlePostPlantUml(req, res)));
     this.app.post('/api',
       (req, res) =>
         upload(req, res, (err) => this.apiController.handlePost(req, res)));
@@ -137,8 +140,6 @@ class Server {
       (req, res) => this.apiController.handleGetList(req, res));
     this.app.get('/api/file/:key/:filename',
       (req, res) => this.apiController.handleGetFile(req.params, res));
-    this.app.get('/api/:id/plantuml',
-      (req, res) => this.apiController.handleGetPlantUml(req.params.id, res));
     this.app.get('/api/:id',
       (req, res) => this.apiController.handleGet(req.params.id, res));
   }

--- a/server.js
+++ b/server.js
@@ -137,6 +137,8 @@ class Server {
       (req, res) => this.apiController.handleGetList(req, res));
     this.app.get('/api/file/:key/:filename',
       (req, res) => this.apiController.handleGetFile(req.params, res));
+    this.app.get('/api/:id/plantuml',
+      (req, res) => this.apiController.handleGetPlantUml(req.params.id, res));
     this.app.get('/api/:id',
       (req, res) => this.apiController.handleGet(req.params.id, res));
   }

--- a/server/controllers/api_controller.js
+++ b/server/controllers/api_controller.js
@@ -54,19 +54,19 @@ class ApiController {
     }
   }
 
-  async handleGetPlantUml(key, res, options = {}) {
+  async handlePostPlantUml(req, res) {
+    const data = req.body;
     res.set('Content-Type', 'image/svg+xml');
-
-    const data = await this.db.models.entries.getEntry(key);
-    winston.verbose('Retrieved document for plantUML', { key });
-
-    const gen = plantuml.generate(data.text, { format: 'svg' });
-    gen.out.pipe(res);
-    
-    fail(res, {
-      clientMsg: 'Unable to generate a plantUML image.',
-      serverMsg: `Problem generating plant UML image: ${params.key}`
-    });
+    try {
+      const gen = plantuml.generate(data.text, { format: 'svg' });
+      gen.out.pipe(res);
+    } catch (err) {
+      return fail(res, {
+        resCode: 500,
+        clientMsg: 'Unable to generate a plantUML image.',
+        serverMsg: `Problem generating plant UML image: ${req.params.id}`
+      });
+    }
   }
 
   async handleRawGet(key, res) {

--- a/server/controllers/api_controller.js
+++ b/server/controllers/api_controller.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import winston from 'winston';
+import plantuml from 'node-plantuml';
 
 import { postgresTimestamp } from '../modules/_helpers';
 import { contentType, fail } from '../modules/response';
@@ -51,6 +52,21 @@ class ApiController {
       res.writeHead(404, contentType.json);
       res.end(JSON.stringify({ message: 'Document not found.' }));
     }
+  }
+
+  async handleGetPlantUml(key, res, options = {}) {
+    res.set('Content-Type', 'image/svg+xml');
+
+    const data = await this.db.models.entries.getEntry(key);
+    winston.verbose('Retrieved document for plantUML', { key });
+
+    const gen = plantuml.generate(data.text, { format: 'svg' });
+    gen.out.pipe(res);
+    
+    fail(res, {
+      clientMsg: 'Unable to generate a plantUML image.',
+      serverMsg: `Problem generating plant UML image: ${params.key}`
+    });
   }
 
   async handleRawGet(key, res) {


### PR DESCRIPTION
- Adds PlantUML support

  **Example**
  
  Saving this text into everpaste:
  ```plantuml
  @startuml
  Alice -> Bob: Authentication Request
  Bob --> Alice: Authentication Response
  
  Alice -> Bob: Another authentication Request
  Alice <-- Bob: Another authentication Response
  @enduml
  ```

  Visit the URL for the paste above and add `/plantuml` to the end of the url
  ![image](https://user-images.githubusercontent.com/7014267/121488472-f4d06c80-c987-11eb-8448-d0630a29dfdb.png)

Also includes:
- Adds routing based render modes (`/:docKey/:renderMode?`) for csv, diff and plantuml
- Hides overflow on the `LoaderBlock` component
- Removes CSV button in the header when `showFile` is `true`
- Adds css helper for white backgrounds (`bg-white`)